### PR TITLE
Fix mobile tab bar wrapping on small screens

### DIFF
--- a/css/tabs.css
+++ b/css/tabs.css
@@ -27,6 +27,7 @@
   padding: 10px 12px;
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
+  text-align: center;
 }
 
 .tab-button:hover:not(:disabled) {
@@ -55,8 +56,39 @@
 }
 
 @media (max-width: 768px) {
+  .tab-bar {
+    display: grid;
+    grid-auto-flow: column;
+    grid-template-rows: repeat(2, minmax(0, 1fr));
+    grid-auto-columns: minmax(0, 1fr);
+    align-items: stretch;
+    align-content: start;
+    overflow: visible;
+  }
+
+  .tab-button {
+    min-width: 0;
+    min-height: 40px;
+    padding: 8px 10px;
+    font-size: 12px;
+    line-height: 1.15;
+  }
+
   .tab-panels {
     min-height: auto;
   }
 }
 
+@media (max-width: 480px) {
+  .tab-bar {
+    gap: 5px;
+    padding: 5px;
+  }
+
+  .tab-button {
+    min-height: 38px;
+    padding: 7px 7px;
+    font-size: 11px;
+    letter-spacing: -0.01em;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
     <link rel="stylesheet" href="./css/base.css?v=20260309a" />
     <link rel="stylesheet" href="./css/header.css?v=20260309a" />
-    <link rel="stylesheet" href="./css/tabs.css?v=20260309a" />
+    <link rel="stylesheet" href="./css/tabs.css?v=20260316a" />
     <link rel="stylesheet" href="./css/wallet-popup.css?v=20260309a" />
     <link rel="stylesheet" href="./css/notifications.css?v=20260309a" />
   </head>


### PR DESCRIPTION
## Summary
- convert the mobile main tab bar to a two-row WhaleSwap-style grid
- remove horizontal scrolling for the bridge tab bar on small viewports
- tighten mobile tab spacing and bump the tab stylesheet cache-buster

## Testing
- verified mobile layout at 390px with no tab-bar horizontal overflow
- verified mobile layout at 320px with no tab-bar horizontal overflow
- verified a forced 5-tab state including Admin/Multisig still fits in two rows
- verified desktop width keeps the existing single-row layout
- verified hash deep-linking and keyboard tab activation still work

Closes #5
<img width="510" height="235" alt="image" src="https://github.com/user-attachments/assets/b251d849-5aa2-4e10-8e29-0973c68e395d" />

<img width="510" height="235" alt="image" src="https://github.com/user-attachments/assets/92196f45-af90-477f-a665-222da66da628" />
