### PR TITLE
Show human-readable current network names

### DIFF
--- a/js/wallet/wallet-popup.js
+++ b/js/wallet/wallet-popup.js
@@ -286,7 +286,7 @@ export class WalletPopup {
 
   _currentNetworkLabel(currentChainId, networks) {
     const found = (networks || []).find((n) => Number(n.chainId) === Number(currentChainId));
-    if (found) return `${found.name} (${found.chainId})`;
+    if (found?.name) return found.name;
     return currentChainId ? `Chain ${currentChainId}` : 'Unknown';
   }
 }


### PR DESCRIPTION
## Summary
- show the configured friendly network name in the wallet popup current-network row
- keep the fallback as  for unsupported networks
- leave the Overview wallet chain card unchanged

## Testing
- verified configured chain labels resolve to friendly names
- verified unknown chains still fall back to 
- verified missing chain IDs still show 

<img width="341" height="419" alt="image" src="https://github.com/user-attachments/assets/e185e703-d2c5-4eda-bd98-21b03dddde58" />


<img width="339" height="409" alt="image" src="https://github.com/user-attachments/assets/534f1757-bab8-44d3-8aa2-9361e263b4e1" />


Closes #4