### PR TITLE
Make transaction sender addresses click-to-copy

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -632,6 +632,27 @@ textarea:focus-visible {
   gap: 4px;
 }
 
+.tx-address-copy {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 4px;
+}
+
+.tx-address-copy:hover:not(:disabled) .tx-code,
+.tx-address-copy:focus-visible .tx-code {
+  color: var(--primary-color);
+  text-decoration: underline;
+}
+
+.tx-address-copy.success .tx-code {
+  color: var(--success-color);
+  animation: copyPulse 0.3s ease;
+}
+
 .tx-ext {
   font-size: 11px;
 }

--- a/js/components/transactions-tab.js
+++ b/js/components/transactions-tab.js
@@ -215,8 +215,21 @@ function renderTxLink(chainKey, txHash) {
 }
 
 function renderAddress(address) {
+  if (!address) return '<span class="tx-muted">--</span>';
   const label = shortenAddress(address);
-  return `<code class="tx-code">${label}</code>`;
+  const fullAddress = String(address);
+  return `
+    <button
+      type="button"
+      class="tx-address-copy"
+      data-copy-address
+      data-address="${fullAddress}"
+      title="${fullAddress}"
+      aria-label="Copy sender address ${fullAddress}"
+    >
+      <code class="tx-code" title="${fullAddress}">${label}</code>
+    </button>
+  `;
 }
 
 function renderChainRoute(src, dst, srcName, dstName) {
@@ -585,6 +598,7 @@ export class TransactionsTab {
     this.pageSizeEl = this.panel.querySelector('[data-tx-page-size]');
 
     this.refreshBtn?.addEventListener('click', () => this.refresh());
+    this.panel.addEventListener('click', (event) => this._handleClick(event));
     this.searchInput?.addEventListener('input', () => {
       this.page = 1;
       this.render();
@@ -707,6 +721,49 @@ export class TransactionsTab {
 
   _setLoading(isLoading) {
     if (this.refreshBtn) this.refreshBtn.disabled = !!isLoading;
+  }
+
+  async _handleClick(event) {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+
+    const copyTrigger = target.closest('[data-copy-address]');
+    if (!copyTrigger) return;
+
+    const address = copyTrigger.getAttribute('data-address') || '';
+    if (!address) return;
+
+    const copied = await this._copy(address);
+    if (!copied) {
+      window.toastManager?.error?.('Failed to copy address');
+      return;
+    }
+
+    copyTrigger.classList.add('success');
+    setTimeout(() => copyTrigger.classList.remove('success'), 900);
+    window.toastManager?.success?.('Address copied to clipboard', { timeoutMs: 1800 });
+  }
+
+  async _copy(text) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        const ok = document.execCommand('copy');
+        document.body.removeChild(ta);
+        return !!ok;
+      } catch {
+        document.body.removeChild(ta);
+        return false;
+      }
+    }
   }
 
   _startIssuedTicker() {


### PR DESCRIPTION
## Summary
- make transaction sender addresses show the full address on hover
- make sender addresses in the Transactions tab click-to-copy without adding a separate copy button
- reuse the existing `data-copy-address` / `data-address` copy hook pattern


Closes #19
