### PR TITLE
Rename Bridge Out tab and make Bridge the default

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,23 +63,23 @@
               class="tab-button is-active"
               role="tab"
               aria-selected="true"
+              aria-controls="tab-panel-bridge"
+              id="tab-bridge"
+              data-tab="bridge"
+              type="button"
+            >
+              Bridge
+            </button>
+            <button
+              class="tab-button"
+              role="tab"
+              aria-selected="false"
               aria-controls="tab-panel-overview"
               id="tab-overview"
               data-tab="overview"
               type="button"
             >
               Overview
-            </button>
-            <button
-              class="tab-button"
-              role="tab"
-              aria-selected="false"
-              aria-controls="tab-panel-bridge-out"
-              id="tab-bridge-out"
-              data-tab="bridge-out"
-              type="button"
-            >
-              Bridge Out
             </button>
             <button
               class="tab-button"
@@ -119,21 +119,21 @@
           <div class="tab-panels">
             <section
               class="tab-panel is-active"
-              id="tab-panel-overview"
+              id="tab-panel-bridge"
               role="tabpanel"
-              aria-labelledby="tab-overview"
+              aria-labelledby="tab-bridge"
               tabindex="0"
-              data-panel="overview"
+              data-panel="bridge"
             ></section>
 
             <section
               class="tab-panel"
-              id="tab-panel-bridge-out"
+              id="tab-panel-overview"
               role="tabpanel"
-              aria-labelledby="tab-bridge-out"
+              aria-labelledby="tab-overview"
               tabindex="0"
               hidden
-              data-panel="bridge-out"
+              data-panel="overview"
             ></section>
 
             <section

--- a/js/components/bridge-out-tab.js
+++ b/js/components/bridge-out-tab.js
@@ -7,7 +7,7 @@ export class BridgeOutTab {
   }
 
   load() {
-    this.panel = document.querySelector('.tab-panel[data-panel="bridge-out"]');
+    this.panel = document.querySelector('.tab-panel[data-panel="bridge"]');
     if (!this.panel) return;
 
     this.module = new PolygonBscBridgeModule({

--- a/js/components/tab-bar.js
+++ b/js/components/tab-bar.js
@@ -28,9 +28,8 @@ export class TabBar {
 
   applyHash() {
     const hash = (window.location.hash || '').replace(/^#/, '').trim();
-    const next = hash && this.tabPanelsByName.has(hash) ? hash : 'overview';
-    const resolved = this._isTabAvailable(next) ? next : 'overview';
-    this.switchTab(resolved, { updateHash: false, focusPanel: false });
+    const next = hash && this.tabPanelsByName.has(hash) ? hash : 'bridge';
+    this.switchTab(next, { updateHash: !!hash && next !== hash, focusPanel: false });
   }
 
   switchTab(tabName, { updateHash = false, focusPanel = false } = {}) {
@@ -116,11 +115,5 @@ export class TabBar {
 
   _getVisibleTabButtons() {
     return this.tabButtons.filter((btn) => !btn.hidden && !btn.classList.contains('hidden'));
-  }
-
-  _isTabAvailable(tabName) {
-    if (tabName === 'overview') return true;
-    const btn = this.tabButtons.find((b) => b.dataset.tab === tabName);
-    return !!btn && !btn.hidden && !btn.classList.contains('hidden');
   }
 }

--- a/js/modules/polygon-bsc-bridge-module.js
+++ b/js/modules/polygon-bsc-bridge-module.js
@@ -95,7 +95,7 @@ export class PolygonBscBridgeModule {
 
     this.container.innerHTML = `
       <div class="panel-header">
-        <h2>Bridge Out</h2>
+        <h2>Bridge</h2>
         <p class="muted">Bridge ${this._tokenSymbol()} from <span data-bridge-source-name></span> to <span data-bridge-dest-name></span>.</p>
       </div>
 


### PR DESCRIPTION
## Summary
- rename the user-facing Bridge Out tab to Bridge
- move Bridge to the first tab position and make it the default landing tab
- align the bridge panel header with the new Bridge label
- use `#bridge` as the bridge tab hash instead of `#bridge-out`

<img width="1125" height="265" alt="image" src="https://github.com/user-attachments/assets/866c3ce4-f0f7-47dd-9082-8499685951db" />

Closes #21