### PR TITLE
Fix wallet popup app network label on first connect

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
   <body>
     <script src="./libs/ethers.umd.min.js?v=20260305c"></script>
-    <script src="./js/app.js?v=20260317m" type="module"></script>
+    <script src="./js/app.js?v=20260317n" type="module"></script>
 
     <div class="container" id="app">
       <header class="header" id="header">

--- a/js/app.js
+++ b/js/app.js
@@ -9,7 +9,7 @@ import { TransactionsTab } from './components/transactions-tab.js?v=20260309n';
 import { ToastManager } from './components/toast-manager.js?v=20260317k';
 import { WalletManager } from './wallet/wallet-manager.js?v=20260317j';
 import { NetworkManager } from './wallet/network-manager.js?v=20260317j';
-import { WalletPopup } from './wallet/wallet-popup.js?v=20260317b';
+import { WalletPopup } from './wallet/wallet-popup.js?v=20260317c';
 import { ContractManager } from './contracts/contract-manager.js?v=20260317e';
 
 const header = new Header();

--- a/js/wallet/wallet-popup.js
+++ b/js/wallet/wallet-popup.js
@@ -259,7 +259,6 @@ export class WalletPopup {
   _appNetworkLabel() {
     const name = window.CONFIG?.NETWORK?.NAME || '';
     const chainId = Number(window.CONFIG?.NETWORK?.CHAIN_ID || 0) || null;
-    if (name && chainId != null) return `${name} (${chainId})`;
     if (name) return name;
     return chainId != null ? `Chain ${chainId}` : 'Unknown';
   }


### PR DESCRIPTION
## Summary
- switch the wallet popup network row to the configured app network
- keep the popup native balance aligned with the app source chain
- bump the wallet popup import and app script cache-busting versions

Closes #32