### PR TITLE
Hide Admin tab by default to avoid first-load flicker

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,17 +74,6 @@
               class="tab-button"
               role="tab"
               aria-selected="false"
-              aria-controls="tab-panel-operations"
-              id="tab-operations"
-              data-tab="operations"
-              type="button"
-            >
-              Admin/Multisig
-            </button>
-            <button
-              class="tab-button"
-              role="tab"
-              aria-selected="false"
               aria-controls="tab-panel-transactions"
               id="tab-transactions"
               data-tab="transactions"
@@ -102,6 +91,20 @@
               type="button"
             >
               Info
+            </button>
+            <button
+              class="tab-button"
+              role="tab"
+              aria-selected="false"
+              aria-hidden="true"
+              aria-controls="tab-panel-operations"
+              id="tab-operations"
+              data-tab="operations"
+              tabindex="-1"
+              hidden
+              type="button"
+            >
+              Admin
             </button>
           </div>
 

--- a/js/components/operations-tab.js
+++ b/js/components/operations-tab.js
@@ -27,7 +27,7 @@ export class OperationsTab {
     this.panel.innerHTML = `
       <div class="panel-header">
         <div class="card-title-row">
-          <h2>Admin / Multisig</h2>
+          <h2>Admin</h2>
           <button type="button" class="btn btn--ghost btn--footer" data-ops-refresh>Refresh</button>
         </div>
         <p class="muted" data-ops-status>Connect a wallet to check access.</p>
@@ -312,7 +312,7 @@ export class OperationsTab {
       if (!this._access.connected) {
         statusEl.textContent = 'Connect a wallet to check access.';
       } else if (!this._access.isAdmin && !this._access.isMultisig) {
-        statusEl.textContent = 'Connected wallet is not allowed to access Admin/Multisig.';
+        statusEl.textContent = 'Connected wallet is not allowed to access Admin.';
       } else if (!txEnabled) {
         statusEl.textContent = `Connected on the wrong network. Transaction actions will prompt a switch to ${this._requiredNetworkName()} when used.`;
       } else {


### PR DESCRIPTION
## Summary
- hide the Admin tab in the initial HTML so it does not flash before access checks run
- rename the tab and panel heading from `Admin/Multisig` to `Admin`
- move the Admin tab to the end of the tab order
- update the unauthorized status copy to match the new label

<img width="1130" height="1289" alt="image" src="https://github.com/user-attachments/assets/722eb22c-dd05-4356-bdac-a1d3e42138df" />


## Follow-ups
- #42
- #43

Closes #29
