### PR TITLE
Fix wallet popup source network label on first connect

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
   <body>
     <script src="./libs/ethers.umd.min.js?v=20260305c"></script>
-    <script src="./js/app.js?v=20260318j" type="module"></script>
+    <script src="./js/app.js?v=20260318k" type="module"></script>
 
     <div class="container" id="app">
       <header class="header" id="header">

--- a/js/app.js
+++ b/js/app.js
@@ -7,8 +7,8 @@ import { OperationsTab } from './components/operations-tab.js?v=20260318b';
 import { TransactionsTab } from './components/transactions-tab.js?v=20260318d';
 import { ToastManager } from './components/toast-manager.js?v=20260317k';
 import { WalletManager } from './wallet/wallet-manager.js?v=20260317j';
-import { NetworkManager } from './wallet/network-manager.js?v=20260318d';
-import { WalletPopup } from './wallet/wallet-popup.js?v=20260317a';
+import { NetworkManager } from './wallet/network-manager.js?v=20260318e';
+import { WalletPopup } from './wallet/wallet-popup.js?v=20260318b';
 import { ContractManager } from './contracts/contract-manager.js?v=20260318b';
 
 const header = new Header();
@@ -21,7 +21,7 @@ const toastManager = new ToastManager();
 const walletManager = new WalletManager();
 const networkManager = new NetworkManager({ walletManager });
 const contractManager = new ContractManager({ walletManager, networkManager });
-const walletPopup = new WalletPopup({ walletManager, networkManager, contractManager });
+const walletPopup = new WalletPopup({ walletManager, contractManager });
 
 document.addEventListener('DOMContentLoaded', async () => {
   window.CONFIG = CONFIG;

--- a/js/wallet/network-manager.js
+++ b/js/wallet/network-manager.js
@@ -116,10 +116,6 @@ export class NetworkManager {
     }
   }
 
-  networkSymbol() {
-    return CONFIG.BRIDGE.CHAINS.SOURCE.NATIVE_CURRENCY.symbol;
-  }
-
   updateUIState() {
     this.updateTxGatedControls();
   }

--- a/js/wallet/wallet-popup.js
+++ b/js/wallet/wallet-popup.js
@@ -1,3 +1,5 @@
+import { CONFIG } from '../config.js';
+
 /**
  * WalletPopup (Phase 2)
  * Simple MetaMask popup:
@@ -7,9 +9,8 @@
  */
 
 export class WalletPopup {
-  constructor({ walletManager, networkManager, contractManager } = {}) {
+  constructor({ walletManager, contractManager } = {}) {
     this.walletManager = walletManager || null;
-    this.networkManager = networkManager || null;
     this.contractManager = contractManager || null;
 
     this.isOpen = false;
@@ -35,6 +36,7 @@ export class WalletPopup {
   async show(anchorEl) {
     const address = this.walletManager?.getAddress?.();
     if (!address) return;
+    const network = CONFIG.BRIDGE.CHAINS.SOURCE;
 
     this._ensureContainer();
     this._containerEl.innerHTML = this._renderHTML({ address, balanceText: 'Loading…' });
@@ -51,12 +53,12 @@ export class WalletPopup {
         const bal = await provider.getBalance(address);
         const formatted = window.ethers.utils.formatEther(bal);
         const display = this._formatBalance(formatted);
-        this._setBalance(`${display} ${this._nativeSymbol()}`);
+        this._setBalance(`${display} ${network.NATIVE_CURRENCY.symbol}`);
       } else {
-        this._setBalance(`-- ${this._nativeSymbol()}`);
+        this._setBalance(`-- ${network.NATIVE_CURRENCY.symbol}`);
       }
     } catch {
-      this._setBalance(`-- ${this._nativeSymbol()}`);
+      this._setBalance(`-- ${network.NATIVE_CURRENCY.symbol}`);
     }
   }
 
@@ -160,16 +162,14 @@ export class WalletPopup {
 
   _renderHTML({ address, balanceText }) {
     const short = this._shortAddress(address);
-    const currentChainId = this.networkManager?.getCurrentChainId?.();
-    const knownNetworks = this.networkManager?.getAvailableNetworks?.() || [];
-    const currentNetworkLabel = this._currentNetworkLabel(currentChainId, knownNetworks);
+    const network = CONFIG.BRIDGE.CHAINS.SOURCE;
     return `
       <div class="wallet-popup" role="dialog" aria-label="Wallet">
         <div class="wallet-popup-content">
           <button class="wallet-popup-close" type="button" title="Close" data-wallet-close>×</button>
 
           <div class="wallet-balance">
-            <div class="balance-label">${this._nativeSymbol()} Balance</div>
+            <div class="balance-label">${network.NATIVE_CURRENCY.symbol} Balance</div>
             <div class="balance-value" data-wallet-balance>${balanceText}</div>
           </div>
 
@@ -181,8 +181,8 @@ export class WalletPopup {
           </div>
 
           <div class="wallet-network">
-            <div class="wallet-network-label">Current Network</div>
-            <div class="wallet-network-value">${currentNetworkLabel}</div>
+            <div class="wallet-network-label">Source Network</div>
+            <div class="wallet-network-value">${network.NAME}</div>
           </div>
 
           <div class="wallet-actions">
@@ -252,15 +252,5 @@ export class WalletPopup {
     if (n === 0) return '0';
     if (n < 0.0001) return '<0.0001';
     return n.toLocaleString(undefined, { maximumFractionDigits: 4 });
-  }
-
-  _nativeSymbol() {
-    return this.networkManager?.networkSymbol?.() || (this.networkManager ? 'MATIC' : 'MATIC');
-  }
-
-  _currentNetworkLabel(currentChainId, networks) {
-    const found = (networks || []).find((n) => Number(n.chainId) === Number(currentChainId));
-    if (found?.name) return found.name;
-    return currentChainId ? `Chain ${currentChainId}` : 'Unknown';
   }
 }


### PR DESCRIPTION
- show the wallet popup network label from the app source chain instead of the wallet current chain
- keep the popup native balance symbol aligned with the source-chain context
- rename the popup field from Current Network to Source Network
- closes #32

Removed:
- the wallet popup's `networkManager` dependency, because the popup now renders source-chain metadata directly from config instead of reading the wallet's active chain
- the popup's dynamic current-network label lookup and fallback text (`Chain <id>` / `Unknown`), because that behavior was what exposed the wallet chain instead of the app chain on first connect
- `NetworkManager.networkSymbol()`, because the popup no longer uses `NetworkManager` to resolve the native currency symbol
