### PR TITLE
Move token config into runtime profiles

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -88,7 +88,6 @@ export const CONFIG = {
   RUNTIME: {
     PROFILE: 'dev', // 'dev' or 'prod'
   },
-  TOKEN: {},
   BRIDGE: {
     LOOKBACK_BLOCKS: 60000,
     COORDINATOR_URL: '',


### PR DESCRIPTION
## Summary
- move token config into the `dev` and `prod` runtime profiles
- resolve `CONFIG.TOKEN` from the active profile during config initialization
- set the production token address to `0x693ed886545970F0a3ADf8C59af5cCdb6dDF0a76`


Fixes #60
