### PR TITLE
feat: move approval into single bridge-out flow

### DIFF
--- a/css/bridge-module.css
+++ b/css/bridge-module.css
@@ -314,7 +314,7 @@
 .bridge-actions {
   margin-top: 0;
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   gap: 12px;
   min-width: 0;
 }
@@ -323,32 +323,6 @@
   width: 100%;
   min-height: 52px;
   font-weight: var(--font-weight-semibold);
-}
-
-.bridge-status {
-  padding: 14px 16px;
-  border-radius: 16px;
-  border: 1px solid var(--border-color);
-  background: rgba(255, 255, 255, 0.92);
-}
-
-.bridge-status-title {
-  font-weight: var(--font-weight-bold);
-  margin-bottom: 6px;
-}
-
-.bridge-status-body {
-  color: var(--secondary-text-color);
-}
-
-.bridge-status-body a {
-  color: var(--primary-color);
-  text-decoration: none;
-  font-weight: var(--font-weight-semibold);
-}
-
-.bridge-status-body a:hover {
-  text-decoration: underline;
 }
 
 @media (max-width: 720px) {
@@ -419,8 +393,7 @@
   }
 
   .bridge-amount-field,
-  .bridge-meta-card,
-  .bridge-status {
+  .bridge-meta-card {
     padding: 12px;
     border-radius: 16px;
   }
@@ -469,7 +442,6 @@
   }
 
   .bridge-actions {
-    grid-template-columns: 1fr;
     gap: 10px;
   }
 }

--- a/js/modules/polygon-bsc-bridge-module.js
+++ b/js/modules/polygon-bsc-bridge-module.js
@@ -1,3 +1,5 @@
+import { createTransactionProgressSession } from '../utils/transaction-progress-session.js';
+
 export class PolygonBscBridgeModule {
   constructor({
     contractManager = null,
@@ -16,13 +18,16 @@ export class PolygonBscBridgeModule {
 
     this._els = {};
     this._lastSnapshot = null;
+    this._balanceCache = null;
     this._refreshTimerId = null;
     this._actionToastSequence = 0;
+    this._bridgeProgressSession = null;
+    this._bridgeProgressVisibilityCleanup = null;
+    this._isBridgePreflightPending = false;
     this._bound = false;
 
     this._onWalletEvent = this._onWalletEvent.bind(this);
     this._onContractUpdated = this._onContractUpdated.bind(this);
-    this._onApproveClicked = this._onApproveClicked.bind(this);
     this._onBridgeClicked = this._onBridgeClicked.bind(this);
     this._onSetMaxClicked = this._onSetMaxClicked.bind(this);
     this._onCopyAddressClicked = this._onCopyAddressClicked.bind(this);
@@ -40,6 +45,7 @@ export class PolygonBscBridgeModule {
 
   destroy() {
     this._unbind();
+    this._clearBridgeProgressSession();
     if (this._refreshTimerId) window.clearTimeout(this._refreshTimerId);
     this._refreshTimerId = null;
     this.container = null;
@@ -62,7 +68,6 @@ export class PolygonBscBridgeModule {
     document.addEventListener('walletChainChanged', this._onWalletEvent);
     document.addEventListener('contractManagerUpdated', this._onContractUpdated);
 
-    this._els.approveBtn?.addEventListener('click', this._onApproveClicked);
     this._els.bridgeBtn?.addEventListener('click', this._onBridgeClicked);
     this._els.setMaxBtn?.addEventListener('click', this._onSetMaxClicked);
     for (const button of this._els.copyAddressButtons) {
@@ -82,7 +87,6 @@ export class PolygonBscBridgeModule {
     document.removeEventListener('walletChainChanged', this._onWalletEvent);
     document.removeEventListener('contractManagerUpdated', this._onContractUpdated);
 
-    this._els.approveBtn?.removeEventListener('click', this._onApproveClicked);
     this._els.bridgeBtn?.removeEventListener('click', this._onBridgeClicked);
     this._els.setMaxBtn?.removeEventListener('click', this._onSetMaxClicked);
     for (const button of this._els.copyAddressButtons) {
@@ -167,10 +171,6 @@ export class PolygonBscBridgeModule {
         <div class="bridge-meta">
           <div class="bridge-meta-card">
             <div class="bridge-meta-row">
-              <div class="bridge-meta-label">Allowance</div>
-              <div class="bridge-meta-value"><span data-bridge-user-allowance>-</span> ${this._tokenSymbol()}</div>
-            </div>
-            <div class="bridge-meta-row">
               <div class="bridge-meta-label">Max bridge out</div>
               <div class="bridge-meta-value"><span data-bridge-max-amount>-</span> ${this._tokenSymbol()}</div>
             </div>
@@ -178,13 +178,7 @@ export class PolygonBscBridgeModule {
         </div>
 
         <div class="actions bridge-actions">
-          <button type="button" class="btn" data-bridge-approve data-requires-tx="true">Approve</button>
           <button type="button" class="btn btn--primary" data-bridge-submit data-requires-tx="true">Bridge Out</button>
-        </div>
-
-        <div class="bridge-status" data-bridge-status hidden>
-          <div class="bridge-status-title" data-bridge-status-title></div>
-          <div class="bridge-status-body" data-bridge-status-body></div>
         </div>
       </div>
     `;
@@ -196,14 +190,9 @@ export class PolygonBscBridgeModule {
       amountField: this.container.querySelector('[data-bridge-amount-field]'),
       amount: this.container.querySelector('[data-bridge-amount]'),
       userBalance: this.container.querySelector('[data-bridge-user-balance]'),
-      userAllowance: this.container.querySelector('[data-bridge-user-allowance]'),
       maxAmount: this.container.querySelector('[data-bridge-max-amount]'),
-      approveBtn: this.container.querySelector('[data-bridge-approve]'),
       bridgeBtn: this.container.querySelector('[data-bridge-submit]'),
       setMaxBtn: this.container.querySelector('[data-bridge-set-max]'),
-      status: this.container.querySelector('[data-bridge-status]'),
-      statusTitle: this.container.querySelector('[data-bridge-status-title]'),
-      statusBody: this.container.querySelector('[data-bridge-status-body]'),
     };
 
     this._syncChainText();
@@ -269,31 +258,52 @@ export class PolygonBscBridgeModule {
   _updateActionStates() {
     const txEnabled = !!this.networkManager?.isTxEnabled?.();
     const connected = !!this.walletManager?.isConnected?.();
+    const session = this._bridgeProgressSession;
     const snapshot = this._lastSnapshot;
-    const balanceWei = this._balanceCache?.balanceWei || null;
+    const amountInput = this._els.amount;
+    if (!amountInput) return;
 
-    if (this._els.amount) this._els.amount.disabled = false;
+    const balanceWei = this._balanceCache?.balanceWei || null;
+    const formLocked = this._isBridgePreflightPending || !!session;
+    amountInput.disabled = formLocked;
 
     const recipient = this._getRecipientAddress();
     const recipientOk = this._isAddress(recipient);
-    const amountWei = this._parseAmountToWei(this._els.amount?.value);
+    const amountWei = this._parseAmountToWei(amountInput.value);
     const hasAmount = !!amountWei && amountWei.gt(0);
     const exceedsBalance = hasAmount && !!balanceWei && amountWei.gt(balanceWei);
     const exceedsMax = hasAmount && !!snapshot?.maxBridgeOutAmount && amountWei.gt(this._bn(snapshot.maxBridgeOutAmount));
 
     const bridgeEnabled = snapshot?.bridgeOutEnabled !== false && snapshot?.halted !== true;
     const amountOk = hasAmount && !exceedsBalance && !exceedsMax;
-    const needsApproval = this._needsApproval(amountWei);
+    const canBridge = connected && recipientOk && amountOk && bridgeEnabled;
 
     this._els.amountField?.classList.toggle('is-invalid', exceedsBalance);
-    this._els.amount?.classList.toggle('is-invalid', exceedsBalance);
+    amountInput.classList.toggle('is-invalid', exceedsBalance);
     this._els.userBalance?.classList.toggle('is-invalid', exceedsBalance);
 
-    if (this._els.approveBtn) this._els.approveBtn.disabled = !connected || !amountOk || !needsApproval;
-    if (this._els.bridgeBtn)
-      this._els.bridgeBtn.disabled =
-        !connected || !recipientOk || !amountOk || !bridgeEnabled || needsApproval;
-    if (this._els.setMaxBtn) this._els.setMaxBtn.disabled = !txEnabled;
+    if (this._els.bridgeBtn) {
+      const button = this._els.bridgeBtn;
+      let disabled = true;
+      let label = 'Bridging...';
+
+      if (!this._isBridgePreflightPending && !session?.isVisible?.()) {
+        if (session?.isHidden?.() && session.isActive()) {
+          disabled = false;
+          label = 'View Progress';
+        } else {
+          disabled = !canBridge;
+          label = 'Bridge Out';
+        }
+      } else if (session?.isVisible?.() && !session.isActive()) {
+        label = 'Checklist Open';
+      }
+
+      button.disabled = disabled;
+      button.classList.toggle('disabled', disabled);
+      button.textContent = label;
+    }
+    if (this._els.setMaxBtn) this._els.setMaxBtn.disabled = !txEnabled || formLocked;
   }
 
   _needsApproval(amountWei) {
@@ -374,98 +384,70 @@ export class PolygonBscBridgeModule {
     this._updateActionStates();
   }
 
-  async _onApproveClicked() {
-    const actionToastId = this._nextActionToastId('bridgeApprove');
-    let toastId = null;
-    try {
-      const address = this.walletManager?.getAddress?.();
-      if (!address) throw new Error('Wallet not connected');
+  _clearBridgeProgressSession() {
+    if (this._bridgeProgressVisibilityCleanup) {
+      this._bridgeProgressVisibilityCleanup();
+      this._bridgeProgressVisibilityCleanup = null;
+    }
 
-      const tokenAddr = await this._getTokenAddress();
-      if (!tokenAddr) throw new Error('Token address not available');
+    this._bridgeProgressSession = null;
+    this._updateActionStates();
+  }
 
-      const amountWei = this._parseAmountToWei(this._els.amount?.value);
-      if (!amountWei || amountWei.lte(0)) throw new Error('Enter a valid amount');
+  _setBridgeProgressSession(session) {
+    if (this._bridgeProgressVisibilityCleanup) {
+      this._bridgeProgressVisibilityCleanup();
+      this._bridgeProgressVisibilityCleanup = null;
+    }
 
-      const vault = this.config.BRIDGE.CONTRACTS.SOURCE.ADDRESS;
-      if (!vault) throw new Error('Vault address not configured');
+    this._bridgeProgressSession = session;
+    if (!session) {
+      this._updateActionStates();
+      return;
+    }
 
-      const approvalRequest = {
-        address,
-        amountWei: amountWei.toString(),
-      };
-
-      const switchResult = await this._ensureRequiredNetworkForAction(actionToastId);
-      toastId = switchResult.toastId || null;
-
-      this._assertActionRequestContext(approvalRequest);
-
-      const signer = this._getRequestSigner(approvalRequest.address);
-      if (!signer) throw new Error('Wallet not connected');
-
-      if (!this._needsApproval(amountWei)) {
-        toastId = this._showActionToast({
-          toastId: toastId || actionToastId,
-          title: 'Done',
-          message: 'Approval already sufficient',
-          type: 'success',
-          timeoutMs: 2500,
-          dismissible: true,
-        });
-        this._showStatus('Approval not needed', 'Current allowance already covers this amount.');
-        this._updateActionStates();
+    this._bridgeProgressVisibilityCleanup = session.onVisibilityChange(({ hidden, active }) => {
+      if (this._bridgeProgressSession !== session) {
         return;
       }
-
-      const token = new window.ethers.Contract(tokenAddr, this._erc20Abi(), signer);
-      toastId = this._showActionLoadingToast({
-        toastId: toastId || actionToastId,
-        message: 'Confirm the approval in your wallet',
-      });
-
-      const tx = await token.approve(vault, amountWei);
-      this._showStatus('Approval submitted', this._txLinkHtml(this.config.BRIDGE.CHAINS.SOURCE.BLOCK_EXPLORER, tx.hash));
-
-      toastId = this._showActionToast({
-        toastId,
-        title: 'Approval submitted',
-        message: `Tx: ${tx.hash}`,
-        type: 'info',
-        timeoutMs: 3500,
-        dismissible: true,
-      });
-
-      await tx.wait(1);
-
-      this._showActionToast({
-        toastId,
-        title: 'Done',
-        message: 'Approval confirmed',
-        type: 'success',
-        timeoutMs: 2500,
-        dismissible: true,
-      });
-      await this._refreshBalances();
+      if (hidden && !active) {
+        this._clearBridgeProgressSession();
+        return;
+      }
       this._updateActionStates();
-    } catch (error) {
-      toastId = toastId || error?._actionToastId || actionToastId;
-      const message = this._actionErrorMessage(error, 'Approval failed');
-      this._showActionToast({ toastId, title: 'Error', message, type: 'error', timeoutMs: 0, dismissible: true });
-      this._showStatus('Approval failed', this._escapeHtml(message));
-    }
+    });
+
+    this._updateActionStates();
   }
 
   async _onBridgeClicked() {
+    if (this._bridgeProgressSession) {
+      if (this._bridgeProgressSession.isHidden()) {
+        this._bridgeProgressSession.reopen();
+      }
+      this._updateActionStates();
+      return;
+    }
+
+    if (this._isBridgePreflightPending) {
+      return;
+    }
+
     const actionToastId = this._nextActionToastId('bridgeOut');
-    let toastId = null;
+    this._isBridgePreflightPending = true;
+    this._updateActionStates();
+
     try {
       const address = this.walletManager?.getAddress?.();
       if (!address) throw new Error('Wallet not connected');
+
+      const amountInput = this._els.amount;
+      if (!amountInput) throw new Error('Amount input is required');
 
       const recipient = this._getRecipientAddress();
       if (!this._isAddress(recipient)) throw new Error('Invalid recipient address');
 
-      const amountWei = this._parseAmountToWei(this._els.amount?.value);
+      const amountWei = this._parseAmountToWei(amountInput.value);
       if (!amountWei || amountWei.lte(0)) throw new Error('Enter a valid amount');
 
       const bridgeRequest = {
@@ -485,79 +467,159 @@ export class PolygonBscBridgeModule {
       if (!bridgeChainId) throw new Error('Bridge chain ID is not configured');
 
       const switchResult = await this._ensureRequiredNetworkForAction(actionToastId);
-      toastId = switchResult.toastId || null;
+      if (switchResult.toastId) {
+        this.toastManager?.dismiss?.(switchResult.toastId);
+      }
 
       this._assertActionRequestContext(bridgeRequest);
 
+      const tokenAddr = await this._getTokenAddress();
+      if (!tokenAddr) throw new Error('Token address not available');
+
+      const vault = this.config.BRIDGE.CONTRACTS.SOURCE.ADDRESS;
+      if (!vault) throw new Error('Vault address not configured');
+
+      const signer = this._getRequestSigner(bridgeRequest.address);
+      if (!signer) throw new Error('Wallet not connected');
+
       let contract = this.contractManager?.getWriteContract?.();
       contract = this._bindWriteContractToRequestAddress(contract, bridgeRequest.address);
-      if (!contract || !this._getRequestSigner(bridgeRequest.address)) throw new Error('Wallet not connected');
+      if (!contract) throw new Error('Wallet not connected');
 
-      if (this._needsApproval(amountWei)) throw new Error('Approval required before bridging');
-
-      toastId = this._showActionLoadingToast({
-        toastId: toastId || actionToastId,
-        message: 'Confirm the bridge transaction in your wallet',
+      const needsApproval = this._needsApproval(amountWei);
+      const stepId = {
+        approve: 'approve-bridge-token',
+        submit: 'submit-bridge-out',
+        confirm: 'confirm-bridge-out',
+      };
+      const progressSession = createTransactionProgressSession(this.toastManager, {
+        title: 'Bridging Out',
+        successTitle: 'Bridge Out Confirmed',
+        failureTitle: 'Bridge Out Failed',
+        cancelledTitle: 'Bridge Out Cancelled',
+        summary: 'Complete the steps below in your wallet and on-chain.',
+        steps: [
+          {
+            id: stepId.approve,
+            label: `Approve ${this._tokenSymbol()}`,
+            status: needsApproval ? 'pending' : 'completed',
+            detail: needsApproval ? '' : 'Already approved',
+          },
+          { id: stepId.submit, label: 'Submit bridge out', status: 'pending', detail: '' },
+          { id: stepId.confirm, label: 'Confirm bridge on-chain', status: 'pending', detail: '' },
+        ],
       });
-      const tx = await contract.bridgeOut(amountWei, recipient, bridgeChainId);
+      this._isBridgePreflightPending = false;
+      this._setBridgeProgressSession(progressSession);
 
-      this._showStatus('Bridge transaction submitted', this._txLinkHtml(this.config.BRIDGE.CHAINS.SOURCE.BLOCK_EXPLORER, tx.hash));
-      toastId = this._showActionToast({
-        toastId,
-        title: 'Bridge submitted',
-        message: `Tx: ${tx.hash}`,
-        type: 'info',
-        timeoutMs: 3500,
-        dismissible: true,
+      if (needsApproval) {
+        const token = new window.ethers.Contract(tokenAddr, this._erc20Abi(), signer);
+        progressSession.updateStep(stepId.approve, { status: 'active', detail: 'Confirm in wallet' });
+
+        let approveTx;
+        try {
+          approveTx = await token.approve(vault, amountWei);
+        } catch (error) {
+          if (this._isUserRejectionError(error)) {
+            progressSession.updateStep(stepId.approve, {
+              status: 'cancelled',
+              detail: 'Wallet request rejected',
+            });
+            progressSession.finishCancelled('Cancelled during token approval.');
+            return;
+          }
+
+          const message = this._actionErrorMessage(error, 'Approval failed');
+          progressSession.updateStep(stepId.approve, { status: 'failed', detail: message });
+          progressSession.finishFailure(message);
+          return;
+        }
+
+        progressSession.updateStep(stepId.approve, { status: 'active', detail: 'Waiting for confirmation' });
+        try {
+          await approveTx.wait(1);
+        } catch (error) {
+          const message = this._actionErrorMessage(error, 'Approval failed');
+          progressSession.updateStep(stepId.approve, { status: 'failed', detail: message });
+          progressSession.finishFailure(message);
+          return;
+        }
+
+        await this._refreshBalances().catch(() => {});
+        await this.contractManager?.refreshStatus?.({ reason: 'bridgeApprovalConfirmed' }).catch(() => {});
+        progressSession.updateStep(stepId.approve, { status: 'completed', detail: 'Approved' });
+      }
+
+      progressSession.updateStep(stepId.submit, { status: 'active', detail: 'Confirm in wallet' });
+
+      let tx;
+      try {
+        tx = await contract.bridgeOut(amountWei, recipient, bridgeChainId);
+      } catch (error) {
+        if (this._isUserRejectionError(error)) {
+          progressSession.updateStep(stepId.submit, {
+            status: 'cancelled',
+            detail: 'Wallet request rejected',
+          });
+          progressSession.finishCancelled('Cancelled before bridge submission.');
+          return;
+        }
+
+        const message = this._actionErrorMessage(error, 'Bridge failed');
+        progressSession.updateStep(stepId.submit, { status: 'failed', detail: message });
+        progressSession.finishFailure(message);
+        return;
+      }
+
+      progressSession.updateStep(stepId.submit, { status: 'completed', detail: 'Submitted' });
+      progressSession.setTransactionLink({
+        hash: tx.hash,
+        url: this._getTransactionExplorerUrl(tx.hash),
       });
+      progressSession.updateStep(stepId.confirm, { status: 'active', detail: 'Waiting for confirmation' });
 
-      const receipt = await tx.wait(1);
+      let receipt;
+      try {
+        receipt = await tx.wait(1);
+      } catch (error) {
+        const message = this._actionErrorMessage(error, 'Bridge failed');
+        progressSession.updateStep(stepId.confirm, { status: 'failed', detail: message });
+        progressSession.finishFailure(message);
+        return;
+      }
+
+      if (receipt?.status === 0) {
+        const message = 'Bridge transaction failed on-chain';
+        progressSession.updateStep(stepId.confirm, { status: 'failed', detail: message });
+        progressSession.finishFailure(message);
+        return;
+      }
 
       const bridgedOut = this._parseBridgedOutFromReceipt(receipt);
+      progressSession.updateStep(stepId.confirm, { status: 'completed', detail: 'Confirmed' });
+      progressSession.finishSuccess(bridgedOut ? 'Bridge out confirmed.' : 'Bridge confirmed.');
+
       if (bridgedOut) {
-        const { from, amount, targetAddress, chainId } = bridgedOut;
-        const msg = `From ${this._shortAddress(from)} • ${this._formatTokenUnits(amount)} ${this._tokenSymbol()} → ${this._shortAddress(
-          targetAddress
-        )} (chain ${chainId})`;
-        this._showActionToast({
-          toastId,
-          title: 'Done',
-          message: 'Bridge out confirmed',
-          type: 'success',
-          timeoutMs: 3500,
-          dismissible: true,
-        });
-        this._showStatus('Bridge out confirmed', this._escapeHtml(msg));
         const detail = {
           txHash: tx.hash,
-          from,
-          amount,
-          targetAddress,
-          targetChainId: Number(chainId),
+          from: bridgedOut.from,
+          amount: bridgedOut.amount,
+          targetAddress: bridgedOut.targetAddress,
+          targetChainId: Number(bridgedOut.chainId),
           sourceChainId: this.config.BRIDGE.CHAINS.SOURCE.CHAIN_ID,
           timestamp: Math.floor(Date.now() / 1000),
         };
         document.dispatchEvent(new CustomEvent('bridgeOutEvent', { detail }));
-      } else {
-        const sourceName = this.config.BRIDGE.CHAINS.SOURCE.NAME;
-        this._showActionToast({
-          toastId,
-          title: 'Done',
-          message: 'Bridge confirmed',
-          type: 'success',
-          timeoutMs: 2500,
-          dismissible: true,
-        });
-        this._showStatus('Bridge confirmed', this._escapeHtml(`Transaction confirmed on ${sourceName}`));
       }
 
       await this._refreshBalances();
-      this._updateActionStates();
     } catch (error) {
-      toastId = toastId || error?._actionToastId || actionToastId;
+      const toastId = error?._actionToastId || actionToastId;
       const message = this._actionErrorMessage(error, 'Bridge failed');
       this._showActionToast({ toastId, title: 'Error', message, type: 'error', timeoutMs: 0, dismissible: true });
-      this._showStatus('Bridge failed', this._escapeHtml(message));
+    } finally {
+      this._isBridgePreflightPending = false;
+      this._updateActionStates();
     }
   }
 
@@ -592,7 +654,6 @@ export class PolygonBscBridgeModule {
     if (!provider || !address) {
       this._balanceCache = null;
       if (this._els.userBalance) this._els.userBalance.textContent = `- ${this._tokenSymbol()} Available`;
-      if (this._els.userAllowance) this._els.userAllowance.textContent = '-';
       this._updateActionStates();
       return;
     }
@@ -614,8 +675,6 @@ export class PolygonBscBridgeModule {
     this._balanceCache = { balanceWei, allowanceWei };
     if (this._els.userBalance)
       this._els.userBalance.textContent = balanceWei ? `${this._formatTokenUnits(balanceWei.toString())} ${this._tokenSymbol()} Available` : `- ${this._tokenSymbol()} Available`;
-    if (this._els.userAllowance)
-      this._els.userAllowance.textContent = allowanceWei ? this._formatTokenUnits(allowanceWei.toString()) : '-';
 
     this._updateActionStates();
   }
@@ -680,17 +739,6 @@ export class PolygonBscBridgeModule {
     }
   }
 
-  _showActionLoadingToast({ toastId = null, message }) {
-    return this._showActionToast({
-      toastId,
-      title: 'Loading',
-      message,
-      type: 'loading',
-      timeoutMs: 0,
-      dismissible: false,
-    });
-  }
-
   _showActionToast({ toastId = null, title, message, type = 'info', timeoutMs = 0, dismissible = true, allowHtml = false }) {
     return (
       this.toastManager?.show?.({
@@ -719,6 +767,14 @@ export class PolygonBscBridgeModule {
       return this._extractActionErrorMessage(error) || `Failed to switch to ${requiredNetworkName}.`;
     }
     return this._extractActionErrorMessage(error) || fallback;
+  }
+
+  _isUserRejectionError(error) {
+    if (error?.code === 4001 || error?.code === 'ACTION_REJECTED') {
+      return true;
+    }
+    const message = this._extractActionErrorMessage(error);
+    return typeof message === 'string' && /rejected/i.test(message);
   }
 
   _extractActionErrorMessage(error) {
@@ -770,17 +826,12 @@ export class PolygonBscBridgeModule {
     }, 250);
   }
 
-  _showStatus(title, bodyHtml) {
-    if (!this._els.status || !this._els.statusTitle || !this._els.statusBody) return;
-    this._els.status.hidden = false;
-    this._els.statusTitle.textContent = String(title || '');
-    this._els.statusBody.innerHTML = String(bodyHtml || '');
-  }
-
-  _txLinkHtml(explorerBase, txHash) {
-    const href = explorerBase ? `${explorerBase.replace(/\/$/, '')}/tx/${txHash}` : '#';
-    const safeHash = this._escapeHtml(txHash);
-    return `<a href="${href}" target="_blank" rel="noopener">${safeHash}</a>`;
+  _getTransactionExplorerUrl(txHash) {
+    const explorerBase = this.config.BRIDGE.CHAINS.SOURCE.BLOCK_EXPLORER;
+    if (!explorerBase || !txHash) {
+      return '';
+    }
+    return `${explorerBase.replace(/\/$/, '')}/tx/${txHash}`;
   }
 
   _erc20Abi() {
@@ -981,14 +1032,5 @@ export class PolygonBscBridgeModule {
     } catch (_) {
       return false;
     }
-  }
-
-  _escapeHtml(text) {
-    return String(text || '')
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#039;');
   }
 }


### PR DESCRIPTION
## Summary
This is review unit 1 of 3 in the clean phase-2 stack.

Goal: convert the bridge UI from a separate `Approve` + `Bridge Out` flow into one `Bridge Out` action backed by the transaction-progress checklist added in `issue-54-phase-1-clean`.

## What Changed
- removes the standalone `Approve` button
- removes the inline bridge status panel
- removes the allowance display row
- keeps one primary `Bridge Out` CTA
- moves approval into the checklist flow when allowance is insufficient
- gives the bridge module ownership of the progress session so hidden sessions can reopen and terminal sessions clear correctly
- updates button labels and disabled states for idle, active, hidden-active, and visible-terminal checklist states
- updates the bridge action layout CSS to a single-column action area

## New Flow
```text
Idle
  |
  v
Bridge Out click
  |
  v
ensure required network
  |
  v
create checklist session
  |
  +--> if approval needed:
  |      approve token
  |
  v
submit bridge tx
  |
  v
wait for on-chain confirmation
  |
  v
terminal checklist state
```

## Files
- `js/modules/polygon-bsc-bridge-module.js`
- `css/bridge-module.css`

## Verification
- module import check for `js/modules/polygon-bsc-bridge-module.js`
- `node --test tests/transaction-progress-session.test.mjs`

## Stack
- base: `issue-54-phase-1-clean`
- next review unit: `issue-54-phase-2-clean-validation`
