### PR TITLE
Track Pending Bridge Transaction Statuses in Transactions Tab

### DIFF
--- a/js/components/transactions-tab.js
+++ b/js/components/transactions-tab.js
@@ -789,7 +789,7 @@ export class TransactionsTab {
 
   _startPendingPoller() {
     if (this._pendingPollerTimer) return;
-    this._pendingPollerTimer = setInterval(() => this._checkPendingStatuses(), 30000);
+    this._pendingPollerTimer = setInterval(() => this._checkPendingStatuses(), 10000);
   }
 
   _stopPendingPoller() {


### PR DESCRIPTION
## Summary
- start a dedicated poller for pending and processing bridge transactions while the Transactions tab is active
- re-check pending transactions as soon as the user returns to the Transactions tab
- merge fresh coordinator data into the existing rows and only re-render when transaction statuses actually change
