### PR TITLE
Simplify transactions tab header UI

### DIFF
--- a/js/components/toast-manager.js
+++ b/js/components/toast-manager.js
@@ -78,10 +78,6 @@ export class ToastManager {
     return this.show({ id, title, message, type: 'success', timeoutMs, dismissible: true, allowHtml });
   }
 
-  warning(message, { title = 'Warning', timeoutMs = 0, id, allowHtml = false } = {}) {
-    return this.show({ id, title, message, type: 'warning', timeoutMs, dismissible: true, allowHtml });
-  }
-
   error(message, { title = 'Error', timeoutMs = 0, id, allowHtml = false } = {}) {
     return this.show({ id, title, message, type: 'error', timeoutMs, dismissible: true, allowHtml });
   }

--- a/js/components/transactions-tab.js
+++ b/js/components/transactions-tab.js
@@ -404,7 +404,7 @@ export class TransactionsTab {
     this.pageInfoEl = this.panel.querySelector('[data-tx-page-info]');
     this.pageSizeEl = this.panel.querySelector('[data-tx-page-size]');
     this.onlyMineCheckbox = this.panel.querySelector('[data-tx-onlymine]');
-    const onlyMineLabel = this.panel.querySelector('[data-tx-onlymine-label]');
+    this.onlyMineLabel = this.panel.querySelector('[data-tx-onlymine-label]');
     this._pendingOnlyMineDefault = !!window.walletManager?.isConnected?.();
 
     this.refreshBtn?.addEventListener('click', () => this.refresh());
@@ -432,13 +432,6 @@ export class TransactionsTab {
       this.page = 1;
       this._updateOnlyMineUI();
       this.render();
-    });
-    onlyMineLabel?.addEventListener('pointerdown', (event) => {
-      if (!this.onlyMineCheckbox?.disabled) return;
-      if (typeof event.button === 'number' && event.button !== 0) return;
-      event.preventDefault();
-      event.stopPropagation();
-      window.toastManager?.warning?.('Connect wallet to use this filter', { timeoutMs: 2500 });
     });
     if (!this._bridgeListenerBound) {
       document.addEventListener('bridgeOutEvent', (e) => this._onBridgeOutEvent(e));
@@ -755,6 +748,9 @@ export class TransactionsTab {
     if (this.onlyMineCheckbox) {
       this.onlyMineCheckbox.checked = !!this.onlyMine;
       this.onlyMineCheckbox.disabled = !connected;
+    }
+    if (this.onlyMineLabel) {
+      this.onlyMineLabel.hidden = !connected;
     }
   }
 

--- a/tests/helpers/test-utils.js
+++ b/tests/helpers/test-utils.js
@@ -56,7 +56,6 @@ export function installCommonWindowStubs({ txEnabled = true } = {}) {
 
   window.toastManager = {
     show: vi.fn(() => null),
-    warning: vi.fn(),
     error: vi.fn(),
     success: vi.fn(),
   };

--- a/tests/transactionsTab.defaultFilter.test.js
+++ b/tests/transactionsTab.defaultFilter.test.js
@@ -84,6 +84,7 @@ describe('TransactionsTab only-my-transactions defaulting', () => {
 
     expect(tab.onlyMine).toBe(true);
     expect(tab.onlyMineCheckbox.checked).toBe(true);
+    expect(tab.onlyMineLabel.hidden).toBe(false);
     expect(tab.page).toBe(1);
     expect(tab.totalEl.textContent).toBe('1');
   });
@@ -109,6 +110,7 @@ describe('TransactionsTab only-my-transactions defaulting', () => {
 
     expect(tab.onlyMine).toBe(false);
     expect(tab.onlyMineCheckbox.checked).toBe(false);
+    expect(tab.onlyMineLabel.hidden).toBe(false);
     expect(tab.totalEl.textContent).toBe('2');
   });
 
@@ -132,6 +134,7 @@ describe('TransactionsTab only-my-transactions defaulting', () => {
 
     expect(tab.onlyMine).toBe(true);
     expect(tab.onlyMineCheckbox.checked).toBe(true);
+    expect(tab.onlyMineLabel.hidden).toBe(false);
     expect(tab.totalEl.textContent).toBe('1');
   });
 
@@ -156,32 +159,8 @@ describe('TransactionsTab only-my-transactions defaulting', () => {
     expect(tab.onlyMine).toBe(true);
     expect(tab.onlyMineCheckbox.checked).toBe(true);
     expect(tab.onlyMineCheckbox.disabled).toBe(false);
+    expect(tab.onlyMineLabel.hidden).toBe(false);
     expect(tab.totalEl.textContent).toBe('1');
-  });
-
-  it('shows a warning when the disabled only mine filter is pressed', () => {
-    const tab = createTab({
-      connected: false,
-      address: null,
-      rows: [
-        makeRow({ txHash: '0xaaa1', from: ADDRESS_ONE }),
-        makeRow({ txHash: '0xbbb2', from: ADDRESS_TWO }),
-      ],
-    });
-    const onlyMineLabel = tab.panel.querySelector('[data-tx-onlymine-label]');
-
-    tab.onlyMineCheckbox.dispatchEvent(new Event('pointerdown', { bubbles: true, cancelable: true }));
-    onlyMineLabel.dispatchEvent(new Event('pointerdown', { bubbles: true, cancelable: true }));
-
-    expect(window.toastManager.warning).toHaveBeenCalledTimes(2);
-    expect(window.toastManager.warning).toHaveBeenNthCalledWith(1, 'Connect wallet to use this filter', {
-      timeoutMs: 2500,
-    });
-    expect(window.toastManager.warning).toHaveBeenNthCalledWith(2, 'Connect wallet to use this filter', {
-      timeoutMs: 2500,
-    });
-    expect(tab.onlyMine).toBe(false);
-    expect(tab.onlyMineCheckbox.checked).toBe(false);
   });
 
   it('unchecks only mine and clears the pending default on disconnect', () => {
@@ -205,6 +184,7 @@ describe('TransactionsTab only-my-transactions defaulting', () => {
     expect(tab.onlyMine).toBe(false);
     expect(tab.onlyMineCheckbox.checked).toBe(false);
     expect(tab.onlyMineCheckbox.disabled).toBe(true);
+    expect(tab.onlyMineLabel.hidden).toBe(true);
     expect(tab.page).toBe(1);
     expect(tab.totalEl.textContent).toBe('2');
 
@@ -212,5 +192,6 @@ describe('TransactionsTab only-my-transactions defaulting', () => {
 
     expect(tab.onlyMine).toBe(false);
     expect(tab.onlyMineCheckbox.checked).toBe(false);
+    expect(tab.onlyMineLabel.hidden).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- shorten the connected-wallet hint to just the short address when the filter is off
- disable the transactions filter checkbox while the wallet is disconnected
- remove the transactions header status strip and use toast errors instead
- keep the transactions default-filter tests aligned with the simpler UI

## Context
This is intentionally split out from issue 83 as a separate cleanup follow-up.

Closes #87

## Testing
- npm test

<img width="1364" height="411" alt="image" src="https://github.com/user-attachments/assets/85d6fdd3-5206-411a-9247-2b4ff2ef88f4" />
<img width="1364" height="411" alt="image" src="https://github.com/user-attachments/assets/cd9691aa-a67d-4121-8dc5-87f84caea5e8" />

<img width="1364" height="411" alt="image" src="https://github.com/user-attachments/assets/d0077fcd-439d-4066-8d8e-caf4c7f27101" />
<img width="1364" height="411" alt="image" src="https://github.com/user-attachments/assets/dbb96ca8-e64a-4519-8661-c8912a3365c0" />
