### PR TITLE
Fix update signer operation payload data

### DIFF
--- a/js/components/operations-tab.js
+++ b/js/components/operations-tab.js
@@ -959,6 +959,7 @@ export class OperationsTab {
     return {
       target: oldAddr,
       value: window.ethers.BigNumber.from(newAddr),
+      data: '0x',
     };
   }
 

--- a/tests/operationsTab.actions.test.js
+++ b/tests/operationsTab.actions.test.js
@@ -5,7 +5,10 @@ import { flushPromises, installCommonWindowStubs, setupOperationsTabDom } from '
 
 const OWNER = '0x1111111111111111111111111111111111111111';
 const NEXT_OWNER = '0x9999999999999999999999999999999999999999';
+const NEXT_SIGNER = '0x2222222222222222222222222222222222222222';
+const BRIDGE_IN_CALLER = '0x3333333333333333333333333333333333333333';
 const OPERATION_ID = `0x${'1'.repeat(64)}`;
+const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
 
 function makeTx(hash) {
   return {
@@ -33,6 +36,25 @@ async function setupAdminTab({ isOwner = true, isSigner = false } = {}) {
   tab.load();
   await tab._syncAccess();
   return tab;
+}
+
+function installPayloadEthersStubs() {
+  window.ethers.constants = {
+    AddressZero: ADDRESS_ZERO,
+    Zero: '0',
+  };
+  window.ethers.BigNumber = {
+    from: vi.fn((value) => ({ kind: 'BigNumber', value, toString: () => String(value) })),
+  };
+  window.ethers.utils.parseUnits = vi.fn((value, decimals) => `parsed:${value}:${decimals}`);
+  window.ethers.utils.defaultAbiCoder = {
+    encode: vi.fn((types, values) => `encoded:${types.join(',')}:${values.join(',')}`),
+  };
+}
+
+function setInputValue(selector, value) {
+  const input = document.querySelector(selector);
+  input.value = value;
 }
 
 describe('OperationsTab action contract pinning', () => {
@@ -126,5 +148,139 @@ describe('OperationsTab action contract pinning', () => {
     expect(sourceContract.transferOwnership).toHaveBeenCalledWith(NEXT_OWNER);
     expect(destinationContract.transferOwnership).not.toHaveBeenCalled();
     expect(window.contractManager.refreshStatus).toHaveBeenCalledWith({ key: 'source', reason: 'ownershipTransferred' });
+  });
+
+  it.each([
+    {
+      contractKey: 'source',
+      opType: 0,
+      name: 'source set bridge out amount',
+      fill: () => setInputValue('[data-op-amount]', '123.45'),
+      expected: {
+        target: ADDRESS_ZERO,
+        value: 'parsed:123.45:18',
+        data: '0x',
+      },
+    },
+    {
+      contractKey: 'source',
+      opType: 1,
+      name: 'source update signer',
+      fill: () => {
+        setInputValue('[data-op-old-signer]', OWNER);
+        setInputValue('[data-op-new-signer]', NEXT_SIGNER);
+      },
+      expected: {
+        target: OWNER,
+        value: expect.objectContaining({ kind: 'BigNumber', value: NEXT_SIGNER }),
+        data: '0x',
+      },
+    },
+    {
+      contractKey: 'source',
+      opType: 2,
+      name: 'source set bridge out enabled',
+      fill: () => setInputValue('[data-op-enabled]', 'false'),
+      expected: {
+        target: ADDRESS_ZERO,
+        value: '0',
+        data: 'encoded:bool:false',
+      },
+    },
+    {
+      contractKey: 'source',
+      opType: 3,
+      name: 'source relinquish tokens',
+      fill: () => {},
+      expected: {
+        target: ADDRESS_ZERO,
+        value: '0',
+        data: '0x',
+      },
+    },
+    {
+      contractKey: 'destination',
+      opType: 0,
+      name: 'destination set bridge in caller',
+      fill: () => setInputValue('[data-op-dest-bridge-in-caller]', BRIDGE_IN_CALLER),
+      expected: {
+        target: BRIDGE_IN_CALLER,
+        value: '0',
+        data: '0x',
+      },
+    },
+    {
+      contractKey: 'destination',
+      opType: 1,
+      name: 'destination set bridge in limits',
+      fill: () => {
+        setInputValue('[data-op-dest-bridge-in-amount]', '456.78');
+        setInputValue('[data-op-dest-bridge-in-cooldown]', '60');
+      },
+      expected: {
+        target: ADDRESS_ZERO,
+        value: 'parsed:456.78:18',
+        data: 'encoded:uint256:60',
+      },
+    },
+    {
+      contractKey: 'destination',
+      opType: 2,
+      name: 'destination update signer',
+      fill: () => {
+        setInputValue('[data-op-old-signer]', OWNER);
+        setInputValue('[data-op-new-signer]', NEXT_SIGNER);
+      },
+      expected: {
+        target: OWNER,
+        value: expect.objectContaining({ kind: 'BigNumber', value: NEXT_SIGNER }),
+        data: '0x',
+      },
+    },
+    {
+      contractKey: 'destination',
+      opType: 3,
+      name: 'destination set bridge in enabled',
+      fill: () => setInputValue('[data-op-dest-bridge-in-enabled]', 'false'),
+      expected: {
+        target: ADDRESS_ZERO,
+        value: '0',
+        data: 'encoded:bool:false',
+      },
+    },
+    {
+      contractKey: 'destination',
+      opType: 4,
+      name: 'destination set bridge out enabled',
+      fill: () => setInputValue('[data-op-dest-bridge-out-enabled]', 'false'),
+      expected: {
+        target: ADDRESS_ZERO,
+        value: '0',
+        data: 'encoded:bool:false',
+      },
+    },
+    {
+      contractKey: 'destination',
+      opType: 5,
+      name: 'destination set min bridge out amount',
+      fill: () => setInputValue('[data-op-dest-min-bridge-out-amount]', '0.5'),
+      expected: {
+        target: ADDRESS_ZERO,
+        value: 'parsed:0.5:18',
+        data: '0x',
+      },
+    },
+  ])('builds a complete request payload for $name', async ({ contractKey, opType, fill, expected }) => {
+    installPayloadEthersStubs();
+    const tab = await setupAdminTab({ isOwner: true, isSigner: false });
+    tab._selectedContractKey = contractKey;
+    fill();
+
+    const payload = tab._buildRequestOperationPayload(opType, contractKey);
+
+    expect(payload).toEqual(expected);
+    expect(payload.target).toBeDefined();
+    expect(payload.value).toBeDefined();
+    expect(payload.data).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- Include explicit empty bytes data (`0x`) for Update Signer operation requests.
- Add payload-construction coverage for every source and destination request operation.

## Root Cause

`requestOperation` always expects `(opType, target, value, data)`. Update Signer does not use extra data during execution, but the ABI still requires the `bytes data` argument. The UI omitted `data`, so ethers attempted to encode `undefined` and could throw `Cannot read properties of undefined (reading 'toHexString')`.
